### PR TITLE
Add support for downloading a single Blackboard module via URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
 # blackboard_crawler
 ###Small app that grabs all pdf files from a specified Blackboard link
 
-This should now work with most any course/degree scheme some slight changes would be needed as I cannot have access to all other courses' blackboard to test. 
-Also for ease of use it would be nice if a GUI was added, I'll try adn do this in the future after more features are added. 
+This should now work with most any course/degree scheme some slight changes would be needed as I cannot have access to all other courses to test.
 
-###Run instructions
+Also for ease of use it would be nice if a GUI was added, I'll try and do this in the future after more features are added.
 
-####On linux:
+###Usage
+
+```
+python3 ./main.py [-u|-url] <AberLearn Module URL> [-h]
+```
+If no URL is specified, the crawler scans Blackboard for any and all available modules to download.
+
+####Linux:
 
 1. Download the contents of dist
 2. In terminal locate the dist folder and cd into it
 3. Run "./main"
 4. Enter username and password
 
-####On other OS's
+####Other OS's
 
-1. From a command line / terminal  
-2. pip install bs4 
+1. From a command line/terminal  
+2. pip install bs4
 3. python main.py


### PR DESCRIPTION
This PR includes support to enable users to download content for an individual module by specifying its associated AberLearn Blackboard URL. This new functionality sits alongside existing behaviour of 'scanning' a user's account for all available BB modules.

**Key Changes:**

- Added ability to specify an individual AberLearn module URL from which to download content.

e.g. 
```
python3 ./main.py -u https://blackboard.aber.ac.uk/webapps/blackboard/execute/modulepage/view?course_id=_9334_1&cmp_tab_id=_21829_1&mode=view 
```

- Added "help"prompt and associated parameter flag. 

e.g. 
```
python3 ./main.py -h

USAGE: main.py [-u|-url=] <BB Module URL>
```

- General tidy-up of bits and bobs.